### PR TITLE
新規投稿ページの改修

### DIFF
--- a/src/Page/New.elm
+++ b/src/Page/New.elm
@@ -1,9 +1,24 @@
 module Page.New exposing (Model, Msg, init, subscriptions, update, view)
 
-import Env exposing (Env)
-import Html exposing (..)
-import Id exposing (Id)
 import Route
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Http
+import Bootstrap.CDN as CDN
+import Bootstrap.Navbar as Navbar
+import Bootstrap.Grid as Grid
+import Bootstrap.Button as Button
+import Bootstrap.Modal as Modal
+import Bootstrap.Form as Form
+import Bootstrap.Form.Input as Input
+import Bootstrap.Form.Textarea as Textarea
+import Bootstrap.Utilities.Spacing as Spacing
+import Env exposing (Env)
+import Threads exposing (..)
+import PageCommon exposing (..)
+
+import Json.Encode as Encode
 
 
 
@@ -12,14 +27,25 @@ import Route
 
 type alias Model =
     { env : Env
+    , thread : Thread
+    , responsePost : PageState ApiResult
+    , navState : Navbar.State
+    , modalVisibility : Modal.Visibility
     }
 
 
 init : Env -> ( Model, Cmd Msg )
 init env =
-    ( Model env
-    , Cmd.none
-    )
+    let
+        thread = Thread 0 "" ""
+        responsePost = NotAsked
+        ( navState, navCmd ) =
+            Navbar.initialState NavMsg
+        modalVisibility = Modal.hidden
+    in
+        ( Model env thread responsePost navState modalVisibility
+        , navCmd
+        )
 
 
 
@@ -27,14 +53,45 @@ init env =
 
 
 type Msg
-    = NoOps
+    = NavMsg Navbar.State
+    | Title String
+    | Content String
+    | Post
+    | Posted (Result Http.Error ApiResult)
+    | CloseModal
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        NoOps ->
-            ( model, Cmd.none )
+        NavMsg state ->
+            ( { model | navState = state }
+            , Cmd.none
+            )
+
+        Title title ->
+            ( { model | thread = Thread model.thread.id title model.thread.content }
+            , Cmd.none
+            )
+
+        Content content ->
+            ( { model | thread = Thread model.thread.id model.thread.title content }
+            , Cmd.none
+            )
+
+        Post ->
+            ( {model | responsePost = Loading }, postThread model.thread)
+
+        Posted result ->
+            case result of
+                Ok postResult ->
+                    ( { model | responsePost = Success postResult, modalVisibility = Modal.shown }, Cmd.none )
+
+                Err error ->
+                    ( { model | responsePost = Failure error }, Cmd.none )
+
+        CloseModal ->
+            ( { model | modalVisibility = Modal.hidden }, Cmd.none )
 
 
 
@@ -43,7 +100,7 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.none
+    Navbar.subscriptions model.navState NavMsg
 
 
 
@@ -52,9 +109,106 @@ subscriptions model =
 
 view : Model -> { title : String, body : List (Html Msg) }
 view model =
-    { title = "elm-my-app - new"
+    { title = "New"
     , body =
-        [ a [ Route.href Route.Index ] [ text "Back to Index" ]
-        , p [] [ text <| "new" ]
+        [ CDN.stylesheet
+        , Grid.container []
+            [ menu model
+            , article [ Spacing.mt2 ]
+                [ Form.form []
+                    [ Form.group []
+                        [ Form.label [ for "title" ] [ text "Title" ]
+                        , Input.text
+                            [ Input.id "title"
+                            , Input.onInput Title
+                            , Input.value model.thread.title
+                            ]
+                        ]
+                    , Form.group []
+                        [ Form.label [ for "content" ] [ text "Content" ]
+                        , Textarea.textarea
+                            [ Textarea.id "content"
+                            , Textarea.rows 5
+                            , Textarea.onInput Content
+                            , Textarea.value model.thread.content
+                            ]
+                        ]
+                    ]
+                , div [ class "text-right" ]
+                    [ Button.button [ Button.primary, Button.attrs [ onClick Post ] ] [ text "Post" ] ]
+                ]
+            ]
+            , Modal.config CloseModal
+            |> Modal.small
+            |> Modal.hideOnBackdropClick True
+            |> Modal.h3 [] [ text "Message" ]
+            |> Modal.body [] [
+                p [] [
+                    case model.responsePost of
+                        Failure err ->
+                            text "Failed..."
+                        
+                        Success postResult ->
+                            text postResult.result
+
+                        Loading ->
+                            text "loading..."
+                        
+                        NotAsked ->
+                            text "not asked"
+                ]
+            ]
+            |> Modal.footer []
+                [ Button.linkButton
+                    [ Button.outlinePrimary
+                    , Button.attrs [ Route.href <| Route.Show 1 ]
+                    ]
+                    [ text "OK" ]
+                ]
+            |> Modal.view model.modalVisibility
         ]
     }
+
+
+-- User-Defined Functions
+
+postThread : Thread -> Cmd Msg
+postThread thread =
+    Http.request
+        { method = "POST"
+        , headers =
+            [ Http.header "Authorization" ("Bearer " ++ "jwt")
+            , Http.header "Accept" "application/json"
+            , Http.header "Content-Type" "application/json"
+            ]
+        , url = "http://127.0.0.1:8000/api/boards/"
+        , expect = Http.expectJson Posted resultDecoder
+        , body = Http.jsonBody <| encodeJsonThread thread
+        , timeout = Nothing
+        , tracker = Nothing
+        }
+
+menu : Model -> Html Msg
+menu model =
+    Navbar.config NavMsg
+        |> Navbar.withAnimation
+        |> Navbar.container
+        |> Navbar.brand [] [ text <| "New" ]
+        |> Navbar.customItems
+            [ Navbar.textItem []
+                [ Button.linkButton
+                    [ Button.outlineDark, Button.attrs [ Spacing.ml1, Route.href Route.Index ] ]
+                    [ text "Back" ]
+                ]
+            ]
+        |> Navbar.view model.navState
+
+encodeJsonThread : Thread -> Encode.Value
+encodeJsonThread thread =
+ let
+     attributes =
+         [ ("title", Encode.string thread.title)
+         , ("content", Encode.string thread.content)
+         ]
+ in
+     Encode.object attributes

--- a/src/PageCommon.elm
+++ b/src/PageCommon.elm
@@ -1,6 +1,7 @@
 module PageCommon exposing (..)
 
 import Http
+import Json.Decode as Decode
 
 type PageState a
     = NotAsked
@@ -8,3 +9,11 @@ type PageState a
     | Success a
     | Failure Http.Error
 
+type alias ApiResult =
+    { result : String
+    }
+
+resultDecoder : Decode.Decoder ApiResult
+resultDecoder =
+    Decode.map ApiResult
+        (Decode.field "result" Decode.string)


### PR DESCRIPTION
新規投稿ページに以下の修正を加える
・Bootstrapの導入
・投稿フォームの作成
・投稿処理の作成
・投稿後のポップアップ表示
・画面遷移処理の作成